### PR TITLE
共通ボタン関係の修正

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -37,6 +37,23 @@ body {
     margin-inline: auto;
 }
 
+/* -------ボタン------- */
+
+.l-btn-area {
+    display: flex;
+    justify-content: center;
+}
+
+.c-btn {
+    display: inline-block;
+    background-color: var(--color-yellow);
+    color: var(--color-black);
+    font-weight: bold;
+    font-size: var(--fz-16px);
+    padding-inline: 48px;
+    padding-block: 16px;
+}
+
 /* ヘッダー
 ----------------------------------------- */
 
@@ -123,8 +140,7 @@ body {
 /* フッター
 ----------------------------------------- */
 
-.l-btn-area {
-    display: flex;
+.l-btn-area--end{
     justify-content: flex-end;
 }
 
@@ -226,16 +242,6 @@ body {
         flex-direction: row;
         justify-content: space-between;
     }
-}
-
-/* -------ボタン------- */
-.c-btn {
-    background-color: var(--color-yellow);
-    color: var(--color-black);
-    font-weight: bold;
-    font-size: var(--fz-16px);
-    padding-inline: 48px;
-    padding-block: 16px;
 }
 
 /* トップページ
@@ -744,11 +750,6 @@ h2 {
     font-weight: bold;
 }
 
-.c-btn--sop-detail {
-    display: flex;
-    justify-content: center;
-}
-
 @media screen and (min-width: 768px) {
     .c-product-introduction {
         flex-direction: row;
@@ -816,20 +817,6 @@ time {
 
 .l-news-cat {
     padding-block: 50px;
-}
-
-.l-news-btn {
-    background-color: var(--color-yellow);
-    width: 152px;
-    height: 66px;
-    padding-inline: 2em;
-    padding-block: 1.2em;
-    margin: 0 auto;
-}
-
-.l-news-btn a {
-    color: var(--color-black);
-    font-weight: bold;
 }
 
 .social-text {

--- a/faq.html
+++ b/faq.html
@@ -161,7 +161,7 @@
     </main>
     <footer class="l-footer">
         <div class="l-wrraper">
-            <div class="l-btn-area">
+            <div class="l-btn-area l-btn-area--end">
                 <a class="c-top-btn" href="#top">top</a>
             </div>
         </div>

--- a/form.html
+++ b/form.html
@@ -160,10 +160,8 @@
 
     <footer class="l-footer">
         <div class="l-wrraper">
-            <div class="l-btn-area">
-                <div class="l-btn-area">
-                    <a class="c-top-btn" href="#top">top</a>
-                </div>
+            <div class="l-btn-area l-btn-area--end">
+                <a class="c-top-btn" href="#top">top</a>
             </div>
         </div>
         <div class="l-footer-inner">

--- a/index.html
+++ b/index.html
@@ -106,7 +106,9 @@
                     </ul>
                     <div class="c-scroll-btn"><img src="./img/btn_scroll.png" alt=""></div>
                 </div>
-                <a class="c-btn c-btn--shop-list" href="shop-list.html">店舗一覧へ</a>
+                <div class="l-btn-area">
+                    <a class="c-btn c-btn--shop-list" href="shop-list.html">店舗一覧へ</a>
+                </div>
             </div>
         </section>
         <section id="event-info" class="c-section c-section--event-info">
@@ -204,10 +206,8 @@
     </main>
     <footer class="l-footer">
         <div class="l-wrraper">
-            <div class="l-btn-area">
-                <div class="l-btn-area">
-                    <a class="c-top-btn" href="#top">top</a>
-                </div>
+            <div class="l-btn-area l-btn-area--end">
+                <a class="c-top-btn" href="#top">top</a>
             </div>
         </div>
         <div class="l-footer-inner">

--- a/news.html
+++ b/news.html
@@ -84,10 +84,8 @@
                     <img class="gyoza-img" src="./img/news_img2.png" alt="餃子を食べる女性">
                 </div>
 
-                <div class="l-news-cat">
-                    <div class="l-news-btn">
-                        <a href="#">一覧に戻る</a>
-                    </div>
+                <div class="l-btn-area l-news-cat">
+                    <a class="c-btn" href="index.html#news">一覧に戻る</a>
                 </div>
 
                 <!-- トップページのお知らせに戻る -->
@@ -124,10 +122,8 @@
 
     <footer class="l-footer">
         <div class="l-wrraper">
-            <div class="l-btn-area">
-                <div class="l-btn-area">
-                    <a class="c-top-btn" href="#top">top</a>
-                </div>
+            <div class="l-btn-area l-btn-area--end">
+                <a class="c-top-btn" href="#top">top</a>
             </div>
         </div>
         <div class="l-footer-inner">

--- a/privacy.html
+++ b/privacy.html
@@ -145,10 +145,8 @@
     </main>
     <footer class="l-footer">
         <div class="l-wrraper">
-            <div class="l-btn-area">
-                <div class="l-btn-area">
-                    <a class="c-top-btn" href="#top">top</a>
-                </div>
+            <div class="l-btn-area l-btn-area--end">
+                <a class="c-top-btn" href="#top">top</a>
             </div>
         </div>
         <div class="l-footer-inner">

--- a/shop-detail.html
+++ b/shop-detail.html
@@ -89,16 +89,16 @@
                     </div>
                 </div>
             </section>
-            <p class="c-btn c-btn--sop-detail"><a href="./shop-list.html">一覧に戻る</a></p>
+            <div class="l-btn-area">
+                <a class="c-btn" href="./shop-list.html">一覧に戻る</a>
+            </div>
         </div>
 
     </main>
     <footer class="l-footer">
         <div class="l-wrraper">
-            <div class="l-btn-area">
-                <div class="l-btn-area">
-                    <a class="c-top-btn" href="#top">top</a>
-                </div>
+            <div class="l-btn-area l-btn-area--end">
+                <a class="c-top-btn" href="#top">top</a>
             </div>
         </div>
         <div class="l-footer-inner">

--- a/shop-list.html
+++ b/shop-list.html
@@ -176,10 +176,8 @@
 
     <footer class="l-footer">
         <div class="l-wrraper">
-            <div class="l-btn-area">
-                <div class="l-btn-area">
-                    <a class="c-top-btn" href="#top">top</a>
-                </div>
+            <div class="l-btn-area l-btn-area--end">
+                <a class="c-top-btn" href="#top">top</a>
             </div>
         </div>
         <div class="l-footer-inner">


### PR DESCRIPTION
#34 
- トップへ戻るボタンの背景部分にタッチ判定がないのを修正
- 上記修正を各ページに反映

#46 
- トップページの店舗一覧セクションから店舗一覧ページ飛ぶためのボタン、お知らせページの一覧に戻るボタン、店舗詳細ページの一覧に戻るボタンのスタイルを1つのクラスで管理できるように統一
- ボタンの配置関係を管理するクラスを追加
  - フッターのトップへ戻るボタンと共通化するための修正